### PR TITLE
spec: requires dovecot-devel >= 2.2.36

### DIFF
--- a/dovecot-antispam.spec
+++ b/dovecot-antispam.spec
@@ -11,7 +11,7 @@ Source0: %{name}-%{version}.tar.gz
 Source1: http://hg.dovecot.org/dovecot-antispam-plugin/archive/%{vhash}.tar.gz
 
 BuildRequires: autoconf, automake, gcc
-BuildRequires: dovecot-devel >= 2.1.16
+BuildRequires: dovecot-devel >= 2.2.36
 BuildRequires: openssl-devel >= 1.0.0
 
 %description 


### PR DESCRIPTION
Fix error:
> Couldn't load required plugin /usr/lib64/dovecot/lib90_antispam_plugin.so:
> Module is for different ABI version 2.2.ABIv10(2.2.10) (we have 2.2.ABIv36(2.2.36))

NethServer/dev#5646

**Before merging, please see [alternative solution](https://wiki2.dovecot.org/Plugins/Antispam)**